### PR TITLE
Update websockets to compatible version

### DIFF
--- a/custom_components/homee/manifest.json
+++ b/custom_components/homee/manifest.json
@@ -12,7 +12,7 @@
     "issue_tracker": "https://github.com/FreshlyBrewedCode/hacs-homee/issues",
     "requirements": [
         "pymee==1.6.0",
-        "websockets==10.3"
+        "websockets==11.0.1"
     ],
     "ssdp": [],
     "version": "2.3.2"


### PR DESCRIPTION
Home Assistant needs a newer websocket version. Fixes issue #33.