### PR TITLE
Add support for Warema Slat Roof and Zip-Screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ The following table shows the available options that can be configured in the "I
 | `Groups that contain door sensors`                                           | empty      | Any `binary_sensor` that is in any of the selected groups will use the `door` device class. You should select a homee group that contains all of your door sensors.                                                                                                                                        |
 | `Add (debug) information about the homee node and attributes to each entity` | `False`    | Enabling this option will add the `homee_data` attribute to every entity created by this integration. The attribute contains information about the homee node (name, id, profile) and the attributes (id, type). This option can be useful for debugging or advanced automations when used with templates. |
 
-## Homee device not correctly working?
-As of now this integration has support for very few devices. If you have devices, that are not discovered or not working correctly, open an issue and do the following to provide a log:
+## Homee device not working correctly?
+As of now this integration has support for very few devices. If you have Homee devices, that are not discovered or not working correctly, open an issue and do the following to provide a log:
 
 1. Add following lines to configuration.yaml to enable info logging for hacs-homee:
 ```

--- a/custom_components/homee/__init__.py
+++ b/custom_components/homee/__init__.py
@@ -23,7 +23,7 @@ from .const import (
     SERVICE_SET_VALUE,
 )
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 # TODO
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
@@ -39,7 +39,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up homee from a config entry."""
-    # Create the Homee api object using host, user and password from the config
+    # Create the Homee api object using host, user, password & pymee instance from the config
     homee = Homee(
         entry.data[CONF_HOST],
         entry.data[CONF_USERNAME],

--- a/custom_components/homee/__init__.py
+++ b/custom_components/homee/__init__.py
@@ -41,7 +41,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up homee from a config entry."""
     # Create the Homee api object using host, user and password from the config
     homee = Homee(
-        entry.data[CONF_HOST], entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
+        entry.data[CONF_HOST],
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        "pymee_" + hass.config.location_name,
     )
 
     # Migrate initial options
@@ -150,7 +153,7 @@ class HomeeNodeEntity:
 
     @property
     def device_info(self):
-        """Holds the available information about the device"""
+        """Holds the available information about the device."""
         if self.has_attribute(AttributeType.SOFTWARE_REVISION):
             sw_version = self.attribute(AttributeType.SOFTWARE_REVISION)
         else:

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -96,7 +96,8 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
         self._unique_id = f"{self._node.id}-cover"
 
-        # Since we only support covers without tilt, there should only be one of these.
+        # TODO needs to be changed, when covers with tilt should be supported
+        # For now there should only be one of these.
         if self.has_attribute(AttributeType.OPEN_CLOSE):
             self._open_close_attribute = AttributeType.OPEN_CLOSE
         elif self.has_attribute(AttributeType.SLAT_ROTATION_IMPULSE):
@@ -123,7 +124,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
     @property
     def current_cover_position(self):
         """Return the cover's position."""
-        # Translate the homee position to HA's 0-100 scale
+        # Translate the homee position values to HA's 0-100 scale
         homee_min = self.get_attribute(self._position_attribute).minimum
         homee_max = self.get_attribute(self._position_attribute).maximum
         homee_position = self.attribute(self._position_attribute)
@@ -133,7 +134,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
     @property
     def is_opening(self):
-        """Return teh opening status of the cover."""
+        """Return the opening status of the cover."""
         return self.attribute(self._open_close_attribute) == 3
 
     @property
@@ -183,9 +184,6 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        # For now, we only know of one device that uses this Attribute.
-        # For other devices the commands may be different.
-        if self._open_close_attribute == AttributeType.SLAT_ROTATION_IMPULSE:
-            await self.async_set_value(self._open_close_attribute, 0)
-        else:
+        if self._open_close_attribute != AttributeType.SLAT_ROTATION_IMPULSE:
+            # The SLAT_ROTATION_IMPULSE does not support stop.
             await self.async_set_value(self._open_close_attribute, 2)

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -177,6 +177,6 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         # For now, we only know of one device that uses this Attribute.
         # For other devices the commands may be different.
         if self._open_close_attribute == AttributeType.SLAT_ROTATION_IMPULSE:
-            await self.async_set_value(self._open_close_attribute, 0_)
+            await self.async_set_value(self._open_close_attribute, 0)
         else:
             await self.async_set_value(self._open_close_attribute, 2)

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -124,7 +124,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         # Translate the homee position to HA's 0-100 scale
         homee_min = self.get_attribute(self._position_attribute).minimum
         homee_max = self.get_attribute(self._position_attribute).maximum
-        homee_position = self.attribute(AttributeType.POSITION)
+        homee_position = self.attribute(self._position_attribute)
         position = ((homee_position - homee_min) / (homee_max - homee_min)) * 100
 
         return 100 - position

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -102,7 +102,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             self._open_close_attribute = AttributeType.OPEN_CLOSE
         elif self.has_attribute(AttributeType.SLAT_ROTATION_IMPULSE):
             self._open_close_attribute = AttributeType.SLAT_ROTATION_IMPULSE
-        else:  # UP_DOWN ist default
+        else:  # UP_DOWN is default
             self._open_close_attribute = AttributeType.UP_DOWN
 
         # Set position can also be controlled with different attributes.

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -145,6 +145,12 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return the state of the cover."""
+        if self.get_attribute(self._position_attribute).options.reverse_control_ui:
+            return (
+                self.attribute(self._position_attribute)
+                == self.get_attribute(self._position_attribute).minimum
+            )
+
         return (
             self.attribute(self._position_attribute)
             == self.get_attribute(self._position_attribute).maximum
@@ -157,18 +163,12 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             # For other devices the commands may be different.
             await self.async_set_value(self._open_close_attribute, 2)
         else:
-            if self.get_attribute(self._position_attribute).options.reverse_control_ui:
-                await self.async_set_value(self._open_close_attribute, 1)
-            else:
-                await self.async_set_value(self._open_close_attribute, 0)
+            await self.async_set_value(self._open_close_attribute, 0)
 
     async def async_close_cover(self, **kwargs):
         """Close cover."""
         # For now, all devices use 1 as close here.
-        if self.get_attribute(self._position_attribute).options.reverse_control_ui:
-            await self.async_set_value(self._open_close_attribute, 0)
-        else:
-            await self.async_set_value(self._open_close_attribute, 1)
+        await self.async_set_value(self._open_close_attribute, 1)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""

--- a/custom_components/homee/cover.py
+++ b/custom_components/homee/cover.py
@@ -149,7 +149,12 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        await self.async_set_value(self._open_close_attribute, 0)
+        # For now, we only know of one device that uses this Attribute.
+        # For other devices the commands may be different.
+        if self._open_close_attribute == AttributeType.SLAT_ROTATION_IMPULSE:
+            await self.async_set_value(self._open_close_attribute, 2)
+        else:
+            await self.async_set_value(self._open_close_attribute, 0)
 
     async def async_close_cover(self, **kwargs):
         """Close cover."""
@@ -169,4 +174,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        await self.async_set_value(self._open_close_attribute, 2)
+        # For now, we only know of one device that uses this Attribute.
+        # For other devices the commands may be different.
+        if self._open_close_attribute == AttributeType.SLAT_ROTATION_IMPULSE:
+            await self.async_set_value(self._open_close_attribute, 0_)
+        else:
+            await self.async_set_value(self._open_close_attribute, 2)


### PR DESCRIPTION
This patch adds support for the above mentioned devices.
It must be said, that I don't own the devices myself and could only test the changes with the help of another user. Also I could not test with other covers and hope it does not break something for these.

The Slat roof uses a range of -45 to 90 in Homee, which has to be translated to the 0-100% range of HA.

The Zip-screens use an option on their up/down-attribute that is named "reverse_control_ui" on the devices where this is set, the up/down commands are reversed and also 100% is open i.s.o. closed.
Adding support for this behaviour is a possible breaking change, if someone worked around this before with some script or configuration in HA, so this should be addressed in the change notes.

I was thinking of delaying this pull request because of [an issue in pymee], but because this seems to not be related to the latest update of the library, I decided to proceed.

[an issue in pymee]: https://github.com/FreshlyBrewedCode/pymee/issues/7